### PR TITLE
Fix player appearance offset

### DIFF
--- a/rt4/Player.java
+++ b/rt4/Player.java
@@ -47,7 +47,7 @@ public class Player extends Actor {
 		}
 		arr = arr.clone();
 		for (int index = 0; index < arr.length; ++index) {
-			arr[index] = arr[index] < 512 ? -1 : arr[index] & 0xfffffdff;
+			arr[index] = arr[index] < 512 ? -1 : arr[index] - 512;
 		}
 		return arr;
 	}


### PR DESCRIPTION
There have been a few commits to this recently, but it was still broken.

Code to demonstrate that using a mask doesn't work #1178 (latest change isn't in client build yet)

```
int wrong = 0, correct = 0;
for (int i = 0; i < 13353; i++) {
    if (((i + 512) & 0xfffffdff) != i) {
        //System.out.println(i + " wrong returns " + ((i + 512) & 0xfffffdff));
        wrong++;
    } else {
        correct++;
    }
}
System.out.println("wrong: " + wrong + ", correct:" + correct);
```

It will currently only work in about half cases (not exactly since you can't wear all items)

`wrong: 6656, correct:6697`



If anyone wants to check this is a list of wearable items that I think will give the incorrect id with the current method https://gist.github.com/Logicail/1efbb5b2b74afe14bec2