### PR TITLE
Elder: Fix new randomization. Store respawn times for all trees

### DIFF
--- a/src/helicopter12/scripts/Elder.java
+++ b/src/helicopter12/scripts/Elder.java
@@ -15,15 +15,15 @@ import org.powerbot.script.Random;
 
 import javax.imageio.ImageIO;
 
-@Script.Manifest(name= "Elder Log Collector", properties = "author=Helicopter12; topic=1296549; client=6;", description = "An autonomous Elder tree chopping and banking system used for money making")
+@Script.Manifest(name = "Elder Log Collector", properties = "author=Helicopter12; topic=1296549; client=6;", description = "An autonomous Elder tree chopping and banking system used for money making")
 public class Elder extends PollingScript<ClientContext> implements PaintListener, MessageListener {
     private String status = "Starting...";
     private final int elderID = 87508;
     private final int deadElderID = 87509, elderLogID = 29556;
     private int logsCollected = 0;
     private int elderPrice;
-    private long[] respawn = new long[4];
-    private long[] spawnTime = new long[4];
+    private long[] respawn = new long[6];
+    private long[] spawnTime = new long[6];
     private final Tile lodeStoneBankTile = new Tile(2899, 3544, 0);
     private final Tile bankTile = new Tile(2887, 3536, 0);
     private final String locationNames[] = { "Varrock:", "Seer's:", "E-Ville:", "E-Peak:", "Draynor1:", "Draynor2:" };
@@ -277,7 +277,7 @@ public class Elder extends PollingScript<ClientContext> implements PaintListener
     @Override
     public void repaint(Graphics graphics) {
         final Graphics2D g = (Graphics2D) graphics;
-        for (int i = 0; i < locationCount; ++i) {
+        for (int i = 0; i < 6; ++i) {
             long spawn = (respawn[i] - getTotalRuntime()) / 1000;
             spawnTime[i] = Math.max(spawn, 0);
         }
@@ -303,7 +303,13 @@ public class Elder extends PollingScript<ClientContext> implements PaintListener
         int spawnIncrement = 20;
         for (int i = 0; i < locationCount; ++i) {
             int coord = spawnBaseCoord + spawnIncrement * i;
-            g.drawString(locationNames[randomizedLocations[i]], 16, coord);
+            int tree = randomizedLocations[i];
+            g.setFont(font3);
+            g.drawString(locationNames[tree], 16, coord);
+            long minutes = spawnTime[tree] / 60;
+            long seconds = spawnTime[tree] % 60;
+            g.setFont(font4);
+            g.drawString(minutes + ":" + seconds, 90, coord);
         }
         g.setFont(font4);
         g.drawString(status, 69, 54);
@@ -312,12 +318,6 @@ public class Elder extends PollingScript<ClientContext> implements PaintListener
                 (logsCollected * elderPrice) / 1000 + "K ("
                         + ((int) (((logsCollected * elderPrice) / 1000) * 3600000D) / getTotalRuntime()) + "k/hr)",
                 66, 93);
-        for (int i = 0; i < 4; ++i) {
-            long minutes = spawnTime[i] / 60;
-            long seconds = spawnTime[i] % 60;
-            int coord = spawnBaseCoord + spawnIncrement * i;
-            g.drawString(minutes + ":" + seconds, 90, coord);
-        }
         g.setFont(font5);
         final long hr = getTotalRuntime() / 3600000;
         final long min = getTotalRuntime() / 60000;
@@ -373,15 +373,15 @@ public class Elder extends PollingScript<ClientContext> implements PaintListener
 
         int next;
 
-        for (next = c + 1; next != c; next = (next+1) % locationCount) {
-            if (spawnTime[next] <= 1) {
+        for (next = c + 1; next != c; next = (next + 1) % locationCount) {
+            if (spawnTime[randomizedLocations[next]] <= 1) {
                 break;
             }
         }
 
-        if (spawnTime[next] > 1) {
+        if (spawnTime[randomizedLocations[next]] > 1) {
             for (int i = 0; i < locationCount; ++i) {
-                if (spawnTime[i] < spawnTime[next]) {
+                if (spawnTime[randomizedLocations[i]] < spawnTime[randomizedLocations[next]]) {
                     next = i;
                 }
             }
@@ -415,8 +415,6 @@ public class Elder extends PollingScript<ClientContext> implements PaintListener
                 int chosen = nums[Random.nextInt(start, 6)];
                 log.info("Replacing tree " + randomizedLocations[currentElderLocation] + " with " + chosen);
                 randomizedLocations[currentElderLocation] = chosen;
-
-                respawn[currentElderLocation] = 0;
             }
         }
     }
@@ -490,7 +488,7 @@ public class Elder extends PollingScript<ClientContext> implements PaintListener
     }
 
     private void triggerTimer() {
-        respawn[currentElderLocation] = getTotalRuntime() + 600000;
+        respawn[randomizedLocations[currentElderLocation]] = getTotalRuntime() + 600000;
     }
 
     // Credit to LodeStone class

--- a/src/helicopter12/scripts/Elder.java
+++ b/src/helicopter12/scripts/Elder.java
@@ -43,7 +43,6 @@ public class Elder extends PollingScript<ClientContext> implements PaintListener
     private Image cursor;
     private String examineNames = "";
     private int currentElderLocation = 0;
-    private String selectedLocations = "";
 
     static enum ScriptState {
         START, BEGIN_CHOP_SEQUENCE, CHOP_LODESTONE_TELEPORT, CHOP_LODESTONE_WAIT, WALK_TO_TREE, CHOP_TREE, BEGIN_BANK_SEQUENCE, BANK_LODESTONE_TELEPORT, BANK_LODESTONE_WAIT, WALK_TO_BANK, PERFORM_BANK,
@@ -69,31 +68,8 @@ public class Elder extends PollingScript<ClientContext> implements PaintListener
             status = "Inventory Full";
         }
 
-        //Randomize the locations and patterns (TEMPORARY - OLD METHOD)
-        int rnd1 = Random.nextInt(0,6);
-        int rnd2 = Random.nextInt(0,6);
-        int rnd3 = Random.nextInt(0,6);
-        int rnd4 = Random.nextInt(0,6);
-
-        while(!lodestoneUnlocked(rnd1)){
-            rnd1 = Random.nextInt(0,6);
-        }
-        while(rnd2 == rnd1 || rnd2 == rnd3 || rnd2 == rnd4 || !lodestoneUnlocked(rnd2)){
-            rnd2 = Random.nextInt(0,6);
-        }
-        while(rnd3 == rnd1 || rnd3 == rnd2 || rnd3 == rnd4 || !lodestoneUnlocked(rnd3)){
-            rnd3 = Random.nextInt(0,6);
-        }
-        while(rnd4 == rnd1 || rnd4 == rnd3 || rnd4 == rnd2 || !lodestoneUnlocked(rnd4)) {
-            rnd4 = Random.nextInt(0,6);
-        }
-        randomizedLocations[0] = rnd1;
-        randomizedLocations[1] = rnd2;
-        randomizedLocations[2] = rnd3;
-        randomizedLocations[3] = rnd4;
-
         // Shuffle locations
-        /*int[] locations = new int[6];
+        int[] locations = new int[6];
         for (int i = 0; i < 6; ++i) {
             locations[i] = i;
         }
@@ -107,12 +83,12 @@ public class Elder extends PollingScript<ClientContext> implements PaintListener
         locationCount = 0;
         for (int loc : locations) {
             if (lodestoneUnlocked(loc)) {
-                randomizedLocations[locationCount++] = locations[loc];
+                randomizedLocations[locationCount++] = loc;
                 if (locationCount == 4) {
                     break;
                 }
             }
-        }*/
+        }
 
         // Grab the price of elder logs
         elderPrice = getPrice();
@@ -218,10 +194,10 @@ public class Elder extends PollingScript<ClientContext> implements PaintListener
                 final Component homeButton2 = ctx.widgets.component(homeWidgetID, homeComponentID);
                 if (homeButton2.valid() && homeButton2.visible()) {
                     status = "Opening map";
-                   if (homeButton2.click()) {
-                       Condition.sleep(Random.nextInt(700, 1000));
-                       step = ScriptState.BANK_LODESTONE_TELEPORT;
-                   }
+                    if (homeButton2.click()) {
+                        Condition.sleep(Random.nextInt(700, 1000));
+                        step = ScriptState.BANK_LODESTONE_TELEPORT;
+                    }
                 }
                 break;
             case BANK_LODESTONE_TELEPORT:
@@ -246,7 +222,7 @@ public class Elder extends PollingScript<ClientContext> implements PaintListener
             case WALK_TO_BANK:
                 // If we are not at the bank tile then walk to it
                 if (ctx.bank.inViewport()) {
-                    ctx.camera.pitch(Random.nextInt(35,65));
+                    ctx.camera.pitch(Random.nextInt(35, 65));
                     step = ScriptState.PERFORM_BANK;
                 } else if (bankTile.distanceTo(ctx.players.local().tile()) > 4) {
                     status = "Walking to Bank";


### PR DESCRIPTION
Previous bug was double-indexing. Found through user testing.

Storing all respawn times preserves more information, to make the script smarter when doing antipattern.