### PR TITLE
Object detection update - Bug fix attempt

### DIFF
--- a/src/helicopter12/scripts/Elder.java
+++ b/src/helicopter12/scripts/Elder.java
@@ -166,7 +166,7 @@ public class Elder extends PollingScript<ClientContext> implements PaintListener
                 break;
             case CHOP_TREE:
                 // Handle the chopping now
-                final GameObject elder = ctx.objects.select().id(elderID).nearest().poll();
+                final GameObject elder = ctx.objects.select(10).id(elderID).poll();
                 if (elder.valid()) {
                     status = "Chopping";
                     if (!elder.inViewport()) {


### PR DESCRIPTION
Object.nearest() seems to be flawed and may cause the script to crash when a player is running toward the object. Removed the object.nearest call and modified the select() call to pass a tile range of 10 to speed things up and serve the same purpose as the nearest call did.