### PR TITLE
Blast Furnace v 1.4c: fixed foreman payment when 60+

### DIFF
--- a/src/andyroo/blastfurnace/BlastFurnace.java
+++ b/src/andyroo/blastfurnace/BlastFurnace.java
@@ -27,6 +27,7 @@ import java.util.concurrent.Callable;
  *
  * v 1.4c
  * fixed attempting to pay foreman when lvl 60+
+ * fixed a bug while collecting that should be handled by idle timer
  *
  */
 
@@ -728,7 +729,7 @@ public class BlastFurnace extends PollingScript<ClientContext> implements PaintL
         } else {  // wait for bars to be ready
 
             // start a timer to check whether still idle
-            if (!waitingForBars && primaryCount() < fullLoad && coalCount() < fullLoad * barType.getRatio() && barCount() < fullLoad) {
+            if (!waitingForBars && (primaryCount() < fullLoad || coalCount() < fullLoad * barType.getRatio()) && barCount() < fullLoad) {
                 log.info("Anti-idle timer start");
                 waitingForBars = true;
                 idleTimer = new Timer();

--- a/src/andyroo/blastfurnace/BlastFurnace.java
+++ b/src/andyroo/blastfurnace/BlastFurnace.java
@@ -19,16 +19,14 @@ import java.util.concurrent.Callable;
 
 @Script.Manifest(
         name = "Blast Furnace", properties = "author=andyroo; topic=1299183; client=4;",
-        description = "v1.4b - Blast furnace (Steel, Mithril, Adamantite only)"
+        description = "v1.4c - Blast furnace (Steel, Mithril, Adamantite only)"
 )
 
 /**
  * Changelog
  *
- * v 1.4b
- * removed black background and change text color to black on gui
- * implemented report widget handler for real this time
- * fixed a bug where script failed to click foreman
+ * v 1.4c
+ * fixed attempting to pay foreman when lvl 60+
  *
  */
 
@@ -131,7 +129,7 @@ public class BlastFurnace extends PollingScript<ClientContext> implements PaintL
     private int startXP;
     private int barsSmelted;
     private int paidCount;
-    private static String version = "1.4b";
+    private static String version = "1.4c";
 
     private BarInfo barType;
 
@@ -199,10 +197,10 @@ public class BlastFurnace extends PollingScript<ClientContext> implements PaintL
 
         if(ctx.skills.level(Constants.SKILLS_SMITHING) < 60) {
             fullLoad = 27;
-            paid = true;
             foremanTimerRunning = false;
         }
         else fullLoad = 28;
+        paid = true;
 
         scriptInit = true;
     }


### PR DESCRIPTION
v 1.4c
fixed foreman payment when 60+
fixed a bug while collecting that should be handled by idle timer
added a check for coins subtracted to confirm payment
now checks exact amount of bars collected (assumed full load before)
urgent.