### PR TITLE
Minimap component failsafe

### DIFF
--- a/rt6/Game.java
+++ b/rt6/Game.java
@@ -407,7 +407,7 @@ public class Game extends ClientAccessor {
 				return c;
 			}
 		}
-		return new Component(ctx, i, -1);
+		return ctx.widgets.component(Constants.MOVEMENT_WIDGET, Constants.MOVEMENT_MAP);
 	}
 
 	private List<Component> mapBlockingComponents() {


### PR DESCRIPTION
Added a failsafe for minimap component parsing if it fails by using ```contentType()```.