### PR TITLE
Updated Inventory components and improved Item#valid() and #stackSize()

### DIFF
--- a/src/org/powerbot/script/rt4/Constants.java
+++ b/src/org/powerbot/script/rt4/Constants.java
@@ -33,8 +33,21 @@ public final class Constants {
 	public static final int GAME_LOADED = 30;
 	public static final int GAME_LOADING = 25;
 
+	public static final int INVENTORY_WIDGET = 149;
+	public static final int INVENTORY_ITEMS = 0;
 	public static final int INVENTORY_BANK_WIDGET = 15;
+	@Deprecated
 	public static final int INVENTORY_BANK = 3;
+	public static final int INVENTORY_BANK_ITEMS = 3;
+	public static final int INVENTORY_GRAND_EXCHANGE_WIDGET = 467;
+	public static final int INVENTORY_GRAND_EXCHANGE_ITEMS = 0;
+	public static final int INVENTORY_SHOP_WIDGET = 301;
+	public static final int INVENTORY_SHOP_ITEMS = 0;
+	public static final int[][] INVENTORY_ALTERNATIVES = {
+			{INVENTORY_BANK_WIDGET, INVENTORY_BANK_ITEMS},
+			{INVENTORY_GRAND_EXCHANGE_WIDGET, INVENTORY_GRAND_EXCHANGE_ITEMS},
+			{INVENTORY_SHOP_WIDGET, INVENTORY_SHOP_ITEMS}
+	};
 
 	public static final int MOVEMENT_MAP = 160;
 	public static final int MOVEMENT_RUN_ENERGY = 23;

--- a/src/org/powerbot/script/rt4/Inventory.java
+++ b/src/org/powerbot/script/rt4/Inventory.java
@@ -16,9 +16,9 @@ public class Inventory extends ItemQuery<Item> {
 	@Override
 	protected List<Item> get() {
 		final List<Item> items = new ArrayList<Item>(28);
-		final Component sub = getComponent();
-		if (sub != null) {
-			for (final Component c : sub.components()) {
+		final Component comp = component();
+		if (comp.componentCount() > 0) {
+			for (final Component c : comp.components()) {
 				final int id = c.itemId();
 				if (id <= -1 || id == 6512 || c.itemStackSize() <= 0) {
 					continue;
@@ -27,56 +27,46 @@ public class Inventory extends ItemQuery<Item> {
 			}
 			return items;
 		}
-
-		Component c = ctx.widgets.widget(149).component(0);
-		if (!c.visible()) {
-			c = ctx.widgets.widget(301).component(0);
-		}
-		final int[] ids = c.itemIds(), stacks = c.itemStackSizes();
+		final int[] ids = comp.itemIds(), stacks = comp.itemStackSizes();
 		for (int i = 0; i < Math.min(ids != null ? ids.length : -1, stacks != null ? stacks.length : -1); i++) {
 			final int id = ids[i], stack = stacks[i];
 			if (id <= 0) {
 				continue;
 			}
-			items.add(new Item(ctx, c, i, id, stack));
+			items.add(new Item(ctx, comp, i, id, stack));
 		}
 		return items;
 	}
 
 	public Item[] items() {
 		final Item[] items = new Item[28];
-		final Component sub = getComponent();
-		if (sub == null) {
-			Component c = ctx.widgets.widget(149).component(0);
-			if (!c.visible()) {
-				c = ctx.widgets.widget(301).component(0);
-			}
-			final int[] ids = c.itemIds(), stacks = c.itemStackSizes();
-			for (int i = 0; i < Math.min(ids != null ? ids.length : -1, stacks != null ? stacks.length : -1); i++) {
-				final int id = ids[i], stack = stacks[i];
-				if (id >= 1) {
-					items[i] = new Item(ctx, c, i, id, stack);
-				} else {
+		final Component comp = component();
+		if (comp.componentCount() > 0) {
+			final Component[] comps = comp.components();
+			final int len = comps.length;
+			for (int i = 0; i < 28; i++) {
+				if (i >= len) {
 					items[i] = nil();
+					continue;
 				}
+				final Component c = comps[i];
+				final int id = c.itemId();
+				if (id <= -1 || id == 6512 || c.itemStackSize() <= 0) {
+					items[i] = nil();
+					continue;
+				}
+				items[i] = new Item(ctx, c, id, c.itemStackSize());
 			}
 			return items;
 		}
-
-		final Component[] comps = sub.components();
-		final int len = comps.length;
-		for (int i = 0; i < 28; i++) {
-			if (i >= len) {
+		final int[] ids = comp.itemIds(), stacks = comp.itemStackSizes();
+		for (int i = 0; i < Math.min(ids != null ? ids.length : -1, stacks != null ? stacks.length : -1); i++) {
+			final int id = ids[i], stack = stacks[i];
+			if (id >= 1) {
+				items[i] = new Item(ctx, comp, i, id, stack);
+			} else {
 				items[i] = nil();
-				continue;
 			}
-			final Component c = comps[i];
-			final int id = c.itemId();
-			if (id <= -1 || id == 6512 || c.itemStackSize() <= 0) {
-				items[i] = nil();
-				continue;
-			}
-			items[i] = new Item(ctx, c, id, c.itemStackSize());
 		}
 		return items;
 	}
@@ -101,8 +91,13 @@ public class Inventory extends ItemQuery<Item> {
 	}
 
 	public Component component() {
-		final Component c = getComponent();
-		return c != null ? c : ctx.widgets.widget(149).component(0);
+		Component c;
+		for (final int[] alt : Constants.INVENTORY_ALTERNATIVES) {
+			if ((c = ctx.widgets.widget(alt[0]).component(alt[1])).valid() && c.visible()) {
+				return c;
+			}
+		}
+		return ctx.widgets.widget(Constants.INVENTORY_WIDGET).component(Constants.INVENTORY_ITEMS);
 	}
 
 	@Override
@@ -110,17 +105,4 @@ public class Inventory extends ItemQuery<Item> {
 		return new Item(ctx, null, -1, -1, -1);
 	}
 
-	private Component getComponent() {
-		Component component = ctx.widgets.widget(Constants.INVENTORY_BANK_WIDGET).component(Constants.INVENTORY_BANK);
-		if (!component.visible()) {
-			component = null;
-		}
-		if (component == null) {
-			component = ctx.widgets.widget(467).component(0);//GE
-			if (!component.visible()) {
-				component = null;
-			}
-		}
-		return component;
-	}
 }

--- a/src/org/powerbot/script/rt4/Item.java
+++ b/src/org/powerbot/script/rt4/Item.java
@@ -17,7 +17,7 @@ public class Item extends GenericItem implements Identifiable, Nameable, Stackab
 	private static final int WIDTH = 42, HEIGHT = 36;
 	final Component component;
 	private final int inventory_index, id;
-	private final int stack;
+	private int stack;
 
 	public Item(final ClientContext ctx, final Component component) {
 		this(ctx, component, component.itemId(), component.itemStackSize());
@@ -64,6 +64,19 @@ public class Item extends GenericItem implements Identifiable, Nameable, Stackab
 
 	@Override
 	public int stackSize() {
+		if (component == null || !component.valid()) {
+			return stack;
+		}
+		if (inventory_index != -1) {
+			final int[] itemIds = component.itemIds();
+			final int[] stackSizes = component.itemStackSizes();
+			return (itemIds.length > inventory_index && stackSizes.length > inventory_index && itemIds[inventory_index] == id
+					? stack = stackSizes[inventory_index]
+					: stack);
+		}
+		if (component.visible() && component.itemId() == id) {
+			return stack = component.itemStackSize();
+		}
 		return stack;
 	}
 
@@ -104,6 +117,13 @@ public class Item extends GenericItem implements Identifiable, Nameable, Stackab
 
 	@Override
 	public boolean valid() {
-		return component != null && component.visible() && id != -1;
+		if (id == -1 || component == null || !component.valid()) {
+			return false;
+		}
+		if (inventory_index != -1) {
+			final int[] itemIds = component.itemIds();
+			return itemIds.length > inventory_index && itemIds[inventory_index] == id;
+		}
+		return !component.visible() || component.itemId() == id;
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/powerbot/powerbot/issues/1420. If no other inventory widgets are visible it always falls back to main inventory widget (149), because it's updated even if it's not visible. This means that inventory query can now be refreshed even if it's closed and it will load the latest data.

This pull request also contains improvements for two Item methods, valid() and stackSize(), which now do the same as their rt6 counterparts.