### PR TITLE
Make rt4 Actor#healthPercent() public

### DIFF
--- a/src/org/powerbot/script/rt4/Actor.java
+++ b/src/org/powerbot/script/rt4/Actor.java
@@ -78,7 +78,7 @@ public abstract class Actor extends Interactive implements InteractiveEntity, Na
 		return data != null && data[1] != null && data[1].getCycleEnd() < client.getCycle();
 	}
 
-	private int healthPercent() {
+	public int healthPercent() {
 		if (!valid()) {
 			return -1;
 		}


### PR DESCRIPTION
Since other methods for getting Actors health are deprecated and now use healthPercent() method, it should be made public.