### PR TITLE
Switch contains condition; Uppercase text for efficiency

### DIFF
--- a/src/org/powerbot/script/Textable.java
+++ b/src/org/powerbot/script/Textable.java
@@ -37,7 +37,7 @@ public interface Textable {
 		public Matcher(final String... texts) {
 			this.texts = new String[texts.length];
 			for (int i = 0; i < texts.length; i++) {
-				this.texts[i] = texts[i].toLowerCase();
+				this.texts[i] = texts[i].toUpperCase();
 			}
 		}
 
@@ -47,9 +47,9 @@ public interface Textable {
 			if (str == null) {
 				return false;
 			}
-			str = str.toLowerCase();
+			str = str.toUpperCase();
 			for (final String text : texts) {
-				if (text != null && text.contains(str)) {
+				if (text != null && str.contains(text)) {
 					return true;
 				}
 			}


### PR DESCRIPTION
Instead of checking whether the desired text contains the entirety of the target, check whether the target contains the entirety of the desired text, [as suggested by Artificial](https://www.powerbot.org/community/topic/1321412-ctxchatselecttext-is-selecting-the-wrong-option/#comment-16179445).

Also, switched `toLowerCase()` to `toUpperCase()` because it's [faster](http://stackoverflow.com/a/29785961).
