### PR TITLE
Add World API

### DIFF
--- a/src/org/powerbot/script/rt4/ClientContext.java
+++ b/src/org/powerbot/script/rt4/ClientContext.java
@@ -34,6 +34,7 @@ public class ClientContext extends org.powerbot.script.ClientContext<Client> {
 	public final Skills skills;
 	public final Varpbits varpbits;
 	public final Widgets widgets;
+	public final Worlds worlds;
 
 	private ClientContext(final Bot bot) {
 		super(bot);
@@ -65,6 +66,7 @@ public class ClientContext extends org.powerbot.script.ClientContext<Client> {
 		skills = new Skills(this);
 		varpbits = new Varpbits(this);
 		widgets = new Widgets(this);
+		worlds = new Worlds(this);
 	}
 
 	/**
@@ -94,6 +96,7 @@ public class ClientContext extends org.powerbot.script.ClientContext<Client> {
 		skills = ctx.skills;
 		varpbits = ctx.varpbits;
 		widgets = ctx.widgets;
+		worlds = ctx.worlds;
 	}
 
 	/**

--- a/src/org/powerbot/script/rt4/World.java
+++ b/src/org/powerbot/script/rt4/World.java
@@ -1,0 +1,215 @@
+package org.powerbot.script.rt4;
+
+import org.powerbot.script.*;
+
+/**
+ * @author Mooshe
+ */
+public class World extends ClientAccessor
+		implements Nillable<World>, Validatable, Identifiable {
+
+	public static final World NIL = new World(null, -1, Integer.MAX_VALUE,
+			Type.UNKNOWN, Server.RUNE_SCAPE, Specialty.NONE);
+
+	public enum Type {
+		FREE(1130),
+		MEMBERS(1131),
+		DEAD_MAN(1237),
+		PVP(1238),
+		UNKNOWN(-1);
+
+		public final int textureId;
+
+		Type(int id) {
+			this.textureId = id;
+		}
+
+		public static Type forType(int id) {
+			for(Type t : values())
+				if(t.textureId == id)
+					return t;
+			return Type.UNKNOWN;
+		}
+	}
+
+	public enum Specialty {
+		NONE,
+		TRADE,
+		MINI_GAME,
+		PVP,
+		DEAD_MAN,
+		SKILL_REQUIREMENT;
+
+		public static Specialty get(String str) {
+			if(str.contains("Trade"))
+				return Specialty.TRADE;
+			if(str.contains("PVP"))
+				return Specialty.PVP;
+			if(str.contains("Deadman"))
+				return Specialty.DEAD_MAN;
+			if(str.contains("skill total"))
+				return Specialty.SKILL_REQUIREMENT;
+			if(!str.contains("-"))
+				return Specialty.MINI_GAME;
+			return Specialty.NONE;
+		}
+	}
+
+	public enum Server {
+		RUNE_SCAPE(-1),
+		NORTH_AMERICA(1133),
+		GERMANY(1140),
+		UNITED_KINGDOM(1135);
+
+		public final int texture;
+
+		Server(int texture) {
+			this.texture = texture;
+		}
+
+		public static Server forType(int texture) {
+			for(Server s : values())
+				if(s.texture == texture)
+					return s;
+			return RUNE_SCAPE;
+		}
+	}
+
+	private final int number, population;
+	private final Type type;
+	private final Server server;
+	private final Specialty specialty;
+
+	public World(ClientContext ctx, int number, int population,
+	             Type type, Server server, Specialty specialty) {
+		super(ctx);
+		this.number = number;
+		this.population = population;
+		this.type = type;
+		this.server = server;
+		this.specialty = specialty;
+	}
+
+	/**
+	 * Grabs the world number.
+	 *
+	 * @return The world number.
+	 */
+	@Override
+	public int id() {
+		return number;
+	}
+
+	/**
+	 * The amount of players in the world.
+	 *
+	 * @return The player count.
+	 */
+	public int size() {
+		return population;
+	}
+
+	/**
+	 * The {@link Type} of world it is.
+	 *
+	 * @return The world type.
+	 */
+	public Type type() {
+		return type;
+	}
+
+	/**
+	 * The {@link Specialty} of the world.
+	 *
+	 * @return The world specialty.
+	 */
+	public Specialty specialty() {
+		return specialty;
+	}
+
+	/**
+	 * The {@link Server} the world is hosted on.
+	 *
+	 * @return The server location.
+	 */
+	public Server server() {
+		return server;
+	}
+
+	/**
+	 * Attempts to hop to this world.
+	 *
+	 * @return <ii>true</ii> if successfully hopped,
+	 * <ii>false</ii> otherwise.
+	 */
+	public boolean hop() {
+		if(!valid())
+			return false;
+		ctx.worlds.open();
+		Component list = ctx.worlds.list();
+		if(list == null || !list.visible()) {
+			return false;
+		}
+		for(Component c : list.components()) {
+			if(c.index() % 6 != 2 || !c.text().equalsIgnoreCase(""+number))
+				continue;
+			ctx.widgets.scroll(list, c, bar());
+			if (c.click()) {
+				return Condition.wait(new ClientStateCondition(45), 100, 20) &&
+						Condition.wait(new ClientStateCondition(30), 100, 100);
+			}
+		}
+		return false;
+	}
+
+	private Component component(int widget, int texture) {
+		for(Component c : ctx.widgets.widget(widget).components())
+			if(c.textureId() == texture)
+				return c;
+		return null;
+	}
+
+	private Component bar() {
+		for(Component c : ctx.widgets.widget(Worlds.WORLD_WIDGET).components())
+			if(c.components().length == 6)
+				return c;
+		return null;
+	}
+
+	@Override
+	public World nil() {
+		return NIL;
+	}
+
+	@Override
+	public boolean valid() {
+		return this.id() > -1;
+	}
+
+	@Override
+
+	public String toString() {
+		return "World[id="+number+"/population="+population+"/type="+type+"/location="+
+				server+"/specialty="+specialty+"]";
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		return (o instanceof World) && ((World) o).number == number;
+	}
+
+	private class ClientStateCondition extends Condition.Check {
+
+		private final int state;
+
+		private ClientStateCondition(int state) {
+			this.state = state;
+		}
+
+
+		@Override
+		public boolean poll() {
+			return ctx.game.clientState() == state;
+		}
+	}
+}

--- a/src/org/powerbot/script/rt4/Worlds.java
+++ b/src/org/powerbot/script/rt4/Worlds.java
@@ -1,0 +1,172 @@
+package org.powerbot.script.rt4;
+
+import org.powerbot.script.AbstractQuery;
+import org.powerbot.script.Condition;
+import org.powerbot.script.Filter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * This class is used to manipulate the world switcher interface.
+ *
+ */
+public class Worlds extends AbstractQuery<Worlds, World, ClientContext> {
+
+	protected static final int WORLD_WIDGET = 69,
+			LOGOUT_WIDGET = 182;
+
+	private ArrayList<World> cache = new ArrayList<World>();
+
+	@Override
+	protected List<World> get() {
+		ArrayList<World> worlds = new ArrayList<World>();
+		Component list = list();
+		if(list == null)
+			return cache;
+		Component[] comps = list.components();
+		for(int off = 0; off < comps.length - 6; off += 6) {
+			World.Type type = World.Type.forType(comps[off + 1].textureId());
+			World.Server server = World.Server.forType(comps[off + 3].textureId());
+			World.Specialty special = World.Specialty.get(comps[off + 5].text());
+			int number = Integer.valueOf(comps[off + 2].text());
+			int population = Integer.valueOf(comps[off + 4].text());
+			worlds.add(new World(ctx, number, population, type, server, special));
+		}
+		cache = new ArrayList<World>(worlds);
+		return worlds;
+	}
+
+	@Override
+	protected Worlds getThis() {
+		return this;
+	}
+
+	/**
+	 * A query of worlds which could be hopped to.
+	 *
+	 * @param ctx The client context.
+	 */
+	public Worlds(ClientContext ctx) {
+		super(ctx);
+	}
+
+	/**
+	 * Filters the worlds by types.
+	 *
+	 * @param types The types to target.
+	 * @return this instance for chaining purposes.
+	 */
+	public Worlds types(final World.Type... types) {
+		return select(new Filter<World>() {
+			public boolean accept(World world) {
+				for(World.Type t : types)
+					if(t.equals(world.type()))
+						return true;
+				return false;
+			}
+		});
+	}
+
+	/**
+	 * Filters the worlds by specialties.
+	 *
+	 * @param specialties The specialties to target.
+	 * @return this instance for chaining purposes.
+	 */
+	public Worlds specialties(final World.Specialty... specialties) {
+		return select(new Filter<World>() {
+			public boolean accept(World world) {
+				for(World.Specialty s : specialties)
+					if(s.equals(world.specialty()))
+						return true;
+				return false;
+			}
+		});
+	}
+
+	/**
+	 * Filters the worlds down to the specified servers.
+	 *
+	 * @param servers The server locations to filter.
+	 * @return This instance for chaining purposes.
+	 */
+	public Worlds servers(final World.Server... servers) {
+		return select(new Filter<World>() {
+			public boolean accept(World world) {
+				for(World.Server s : servers)
+					if(s.equals(world.server()))
+						return true;
+				return false;
+			}
+		});
+	}
+
+	/**
+	 * Filters the worlds by player count. This will filter down to any world
+	 * which is less than or equal to the parameter.
+	 *
+	 * @param population The population the worlds should be less than or equal to.
+	 * @return this instance for chaining purposes.
+	 */
+	public Worlds population(final int population) {
+		return select(new Filter<World>() {
+			public boolean accept(World world) {
+				return world.size() <= population;
+			}
+		});
+	}
+
+	/**
+	 * Filters the worlds by joinable worlds. This will filter out any
+	 * dangerous or skill-required worlds.
+	 *
+	 * @return this instance for chaining purposes.
+	 */
+	public Worlds joinable() {
+		return select(new Filter<World>() {
+			public boolean accept(World world) {
+				return world.valid() &&
+						world.type() != World.Type.DEAD_MAN &&
+						world.specialty() != World.Specialty.PVP &&
+						world.specialty() != World.Specialty.SKILL_REQUIREMENT;
+			}
+		});
+	}
+
+	/**
+	 * Opens the world switcher.
+	 *
+	 * @return <ii>true</ii> if successfully opened, <ii>false</ii> otherwise.
+	 */
+	public boolean open() {
+		ctx.game.tab(Game.Tab.LOGOUT);
+		if(ctx.widgets.widget(WORLD_WIDGET).valid())
+			return true;
+		Component c = component(LOGOUT_WIDGET, "World Switcher");
+		return c != null && c.click() && Condition.wait(new Condition.Check() {
+			public boolean poll() {
+				return ctx.widgets.widget(WORLD_WIDGET).valid();
+			}
+		}, 100, 20);
+	}
+
+	@Override
+	public World nil() {
+		return World.NIL;
+	}
+
+	protected final Component list() {
+		for(Component c : ctx.widgets.widget(WORLD_WIDGET).components())
+			if(c.width() == 174 && c.height() == 204)
+				return c;
+		return null;
+	}
+
+	protected final Component component(int widget, String text) {
+		for(Component c : ctx.widgets.widget(widget).components())
+			if(c.text().equalsIgnoreCase(text))
+				return c;
+		return null;
+	}
+}


### PR DESCRIPTION
This World API allows users to select and filter possible worlds to join via the world switcher interface in Oldschool RuneScape. Here's an example:

``` java
ctx.worlds.open(); // Opens world switcher widget
ctx.worlds.select()
        .joinable() // Selects and filters all worlds which are not PVP, DMM, or skill-required.
        .types(Type.FREE) // Filters all worlds which are free
        .servers(Server.NORTH_AMERICA) // Only filters down to north american servers
        .population(1000) // Filters down to worlds with less than or equal to 1000 players on
ctx.worlds.peek().hop(); // Hops to the specified world
```
