### PR TITLE
Fixed random events dismiss spamming

### DIFF
--- a/src/org/powerbot/bot/rt4/RandomEvents.java
+++ b/src/org/powerbot/bot/rt4/RandomEvents.java
@@ -1,5 +1,6 @@
 package org.powerbot.bot.rt4;
 
+import org.powerbot.script.Condition;
 import org.powerbot.script.Filter;
 import org.powerbot.script.PollingScript;
 import org.powerbot.script.rt4.ClientContext;
@@ -30,7 +31,14 @@ public class RandomEvents extends PollingScript<ClientContext> {
 		if (!threshold.contains(this)) {
 			threshold.add(this);
 		}
-
-		ctx.npcs.poll().interact(false, "Dismiss");
+		final Npc npc;
+		if ((npc = ctx.npcs.poll()).interact(false, "Dismiss")) {
+			Condition.wait(new Condition.Check() {
+				@Override
+				public boolean poll() {
+					return !npc.valid();
+				}
+			}, 300, 12);
+		}
 	}
 }


### PR DESCRIPTION
This fixes an issue where the bot would spam-click the "Dismiss" command until the npc disappeared.