### PR TITLE
Fixed rt4 Actor#healthPercent()

### DIFF
--- a/src/org/powerbot/script/rt4/Actor.java
+++ b/src/org/powerbot/script/rt4/Actor.java
@@ -133,7 +133,7 @@ public abstract class Actor extends Interactive implements InteractiveEntity, Na
 		if (data == null || data[1] == null) {
 			return 100;
 		}
-		return (int) Math.ceil(data[1].getHealthRatio() * 100d / 255d);
+		return (int) Math.ceil(data[1].getHealthRatio() * 100d / 30d);
 	}
 
 	/**


### PR DESCRIPTION
Solves https://github.com/powerbot/powerbot/issues/1519

[CombatStatusData#getHealthRatio()](https://github.com/powerbot/powerbot/blob/rsbot-api/src/org/powerbot/bot/rt4/client/CombatStatusData.java#L14-L16) returns 30 when health bar is visible and actor has full hp. Tested with both Npcs and Players and it returns the correct value.