### PR TITLE
Improved rt6 interactions, added tooltip menu command and some documentation

### DIFF
--- a/src/org/powerbot/script/rt6/Interactive.java
+++ b/src/org/powerbot/script/rt6/Interactive.java
@@ -137,7 +137,7 @@ public abstract class Interactive extends ClientAccessor implements org.powerbot
 				return Condition.wait(new Condition.Check() {
 					@Override
 					public boolean poll() {
-						return ctx.menu.indexOf(c) == 0;
+						return ctx.menu.indexOf(c) == 0 || c.accept(ctx.menu.tooltip());
 					}
 				}, 10, 30) && ctx.input.click(true);
 			}


### PR DESCRIPTION
Sometimes there are a lot of players in front of the entity you're trying to interact with and the client gets stuck in a continuous loop if the menu command is off-screen. You can still left-click it in this case.

This update checks the tooltip if you can still left-click the entity or not and fixes https://github.com/powerbot/powerbot/issues/1419.