### PR TITLE
Fixed rt4 Item#nextPoint()

### DIFF
--- a/src/org/powerbot/script/rt4/Item.java
+++ b/src/org/powerbot/script/rt4/Item.java
@@ -93,7 +93,8 @@ public class Item extends GenericItem implements Identifiable, Nameable, Stackab
 		if (inventory_index != -1) {
 			final Point base = component.screenPoint();
 			final Rectangle r = new Rectangle(base.x - 3 + (inventory_index % 4) * WIDTH, base.y - 2 + (inventory_index / 4) * HEIGHT, WIDTH, HEIGHT);
-			return Calculations.nextPoint(r, new Rectangle(r.x + r.width / 2, r.y + r.height / 2, r.width / 4, r.height / 4));
+			final int xOff = r.width / 8, yOff = r.height / 8;
+			return Calculations.nextPoint(r, new Rectangle(r.x + r.width / 2 - xOff, r.y + r.height / 2 - yOff, r.width / 4, r.height / 4));
 		}
 		return component.nextPoint();
 	}


### PR DESCRIPTION
Fixes the mean in next point calculation. Center rectangle must be offset for 1/8 of the bounding one in order for its center point to be the actual item center point. Fixes https://github.com/powerbot/powerbot/issues/1592, @Moosheplusplus the deviation looks fine.