### PR TITLE
added hotkey option to close bank

### DIFF
--- a/src/main/java/org/powerbot/script/rt6/Bank.java
+++ b/src/main/java/org/powerbot/script/rt6/Bank.java
@@ -186,13 +186,20 @@ public class Bank extends ItemQuery<Item> implements Viewable {
 		return opened();
 	}
 
+	public boolean close() {
+		return close(false);
+	}
+
 	/**
-	 * Closes the bank by the 'X'.
+	 * Closes the bank. If true, uses the hotkey (ESC). If false, clicks 'X'.
 	 *
 	 * @return <tt>true</tt> if the bank was closed; otherwise <tt>false</tt>
 	 */
-	public boolean close() {
-		return !opened() || ctx.widgets.component(Constants.BANK_WIDGET, Constants.BANK_CLOSE).click("Close") && Condition.wait(new Condition.Check() {
+	public boolean close(final boolean hotkey) {
+		return !opened()
+				|| ((hotkey && ctx.input.send(Constants.HOTKEY_CLOSE))
+				|| ctx.widgets.component(Constants.BANK_WIDGET, Constants.BANK_CLOSE).click("Close"))
+				&& Condition.wait(new Condition.Check() {
 			@Override
 			public boolean poll() {
 				return !opened();

--- a/src/main/java/org/powerbot/script/rt6/Constants.java
+++ b/src/main/java/org/powerbot/script/rt6/Constants.java
@@ -285,4 +285,6 @@ public final class Constants {
 	};
 	public static final int[] WIDGETCLOSER_FATAL = {
 	};
+
+	public static final String HOTKEY_CLOSE = "{VK_ESCAPE}";
 }


### PR DESCRIPTION
- adds a `bank.close(boolean)` method, which allows the user to specify whether to use the hotkey or the mouse.
- keeps the default `bank.close()` as an overloaded method; returns `bank.close(false)` by default to keep all script behaviors the same.