### PR TITLE
Fix random event dismissal

### DIFF
--- a/src/main/java/org/powerbot/bot/rt4/RandomEvents.java
+++ b/src/main/java/org/powerbot/bot/rt4/RandomEvents.java
@@ -35,7 +35,7 @@ public class RandomEvents extends PollingScript<ClientContext> {
 			threshold.add(this);
 		}
 		
-		 if(ctx.inventory.selectedItemIndex()>=0){
+		 if(ctx.inventory.selectedItemIndex() >= 0){
 			ctx.inventory.selectedItem().click();
 		}
 		

--- a/src/main/java/org/powerbot/bot/rt4/RandomEvents.java
+++ b/src/main/java/org/powerbot/bot/rt4/RandomEvents.java
@@ -34,6 +34,11 @@ public class RandomEvents extends PollingScript<ClientContext> {
 		if (!threshold.contains(this)) {
 			threshold.add(this);
 		}
+		
+		 if(ctx.inventory.selectedItemIndex()>=0){
+			ctx.inventory.selectedItem().click();
+		}
+		
 		final Npc npc = ctx.npcs.poll();
 		if(ctx.input.move(npc.nextPoint())) {
 			for(MenuCommand a : ctx.menu.commands()) {


### PR DESCRIPTION
random events can not be dismissed by the client if they occur when an
inventory item is selected, this will deselect the item if one is
selected