### PR TITLE
Fix world hopping

### DIFF
--- a/src/main/java/org/powerbot/script/rt4/World.java
+++ b/src/main/java/org/powerbot/script/rt4/World.java
@@ -10,6 +10,10 @@ public class World extends ClientAccessor
 
 	public static final World NIL = new World(null, -1, Integer.MAX_VALUE,
 			Type.UNKNOWN, Server.RUNE_SCAPE, Specialty.NONE);
+			
+	public static final int WORLD_SWITCH_PARENT = 219;
+	public static final int WORLD_SWITCH_RISK = 2;
+	public static final int WORLD_SWITCH_REGULAR = 1;
 
 	public enum Type {
 		FREE(1130),
@@ -155,6 +159,13 @@ public class World extends ClientAccessor
 				continue;
 			ctx.widgets.scroll(list, c, bar());
 			if (c.click()) {
+				if(ctx.chat.canContinue()){
+				    if(ctx.widgets.component(WORLD_SWITCH_PARENT,0).component(WORLD_SWITCH_RISK).valid()){
+					ctx.widgets.component(WORLD_SWITCH_PARENT,0).component(WORLD_SWITCH_RISK).click();
+				    } else if(ctx.widgets.component(WORLD_SWITCH_PARENT,0).component(WORLD_SWITCH_REGULAR).valid()){
+					ctx.widgets.component(WORLD_SWITCH_PARENT,0).component(WORLD_SWITCH_REGULAR).click();
+				    }
+				}
 				return Condition.wait(new ClientStateCondition(45), 100, 20) &&
 						Condition.wait(new ClientStateCondition(30), 100, 100);
 			}

--- a/src/main/java/org/powerbot/script/rt4/World.java
+++ b/src/main/java/org/powerbot/script/rt4/World.java
@@ -10,10 +10,7 @@ public class World extends ClientAccessor
 
 	public static final World NIL = new World(null, -1, Integer.MAX_VALUE,
 			Type.UNKNOWN, Server.RUNE_SCAPE, Specialty.NONE);
-			
-	public static final int WORLD_SWITCH_PARENT = 219;
-	public static final int WORLD_SWITCH_RISK = 2;
-	public static final int WORLD_SWITCH_REGULAR = 1;
+
 
 	public enum Type {
 		FREE(1130),
@@ -159,11 +156,9 @@ public class World extends ClientAccessor
 				continue;
 			ctx.widgets.scroll(list, c, bar());
 			if (c.click()) {
-				if(ctx.chat.canContinue()){
-				    if(ctx.widgets.component(WORLD_SWITCH_PARENT,0).component(WORLD_SWITCH_RISK).valid()){
-					ctx.widgets.component(WORLD_SWITCH_PARENT,0).component(WORLD_SWITCH_RISK).click();
-				    } else if(ctx.widgets.component(WORLD_SWITCH_PARENT,0).component(WORLD_SWITCH_REGULAR).valid()){
-					ctx.widgets.component(WORLD_SWITCH_PARENT,0).component(WORLD_SWITCH_REGULAR).click();
+				if(!ctx.chat.pendingInput()) {
+				    if (!ctx.chat.continueChat("Switch")) {
+					ctx.chat.continueChat("Yes.");
 				    }
 				}
 				return Condition.wait(new ClientStateCondition(45), 100, 20) &&


### PR DESCRIPTION
Current implementation does not consider the chat you have to answer to enter PVP and high risk worlds, and also all worlds if the user hasn't disabled it. This may have been by choice to stop people entering PVP worlds by accident, but it should be up to the develop to select the right world rather than for the client to not support it by default.

Unsure if we should have a wait condition before checking ctx.chat.canContinue() but I believe this would work as is.

would fix #1757 