### PR TITLE
Failsafe if wrong bank tab is open

### DIFF
--- a/src/main/java/org/powerbot/script/rt4/Bank.java
+++ b/src/main/java/org/powerbot/script/rt4/Bank.java
@@ -244,6 +244,9 @@ public class Bank extends ItemQuery<Item> {
 			action = "Withdraw-X";
 		}
 		final int cache = ctx.inventory.select().count(true);
+		if(!item.component().visible()){
+         	   ctx.bank.currentTab(0);
+        	}
 		if (item.contains(ctx.input.getLocation())) {
 			if (!(ctx.menu.click(new Filter<MenuCommand>() {
 				@Override


### PR DESCRIPTION
unlike rs3 osrs bank tabs only show the items in the tab, so if the user had a tab open when they last played and then starts a script - the script just dies if it requires banking

this checks the component is visible and if not then it opens tab 0 which will display all of the items in the bank