### PR TITLE
fix broken banking edge case

### DIFF
--- a/src/main/java/org/powerbot/script/rt4/Widgets.java
+++ b/src/main/java/org/powerbot/script/rt4/Widgets.java
@@ -102,7 +102,12 @@ public class Widgets extends IdQuery<Widget> {
 		if (bar == null || !bar.valid() || ((childrenCount = bar.componentCount()) != 6 && childrenCount != 7)) {
 			return false;
 		}
-		if (pane == null || !pane.valid() || pane.scrollHeight() == 0) {
+		
+		if(pane.scrollHeight() == 0){
+			return true;
+		}
+		
+		if (pane == null || !pane.valid()) {
 			return false;
 		}
 		final Point view = pane.screenPoint();

--- a/src/main/java/org/powerbot/script/rt4/Widgets.java
+++ b/src/main/java/org/powerbot/script/rt4/Widgets.java
@@ -101,15 +101,16 @@ public class Widgets extends IdQuery<Widget> {
 		final int childrenCount;
 		if (bar == null || !bar.valid() || ((childrenCount = bar.componentCount()) != 6 && childrenCount != 7)) {
 			return false;
+		}		
+		
+		if (pane == null || !pane.valid()) {
+			return false;
 		}
 		
 		if(pane.scrollHeight() == 0){
 			return true;
 		}
 		
-		if (pane == null || !pane.valid()) {
-			return false;
-		}
 		final Point view = pane.screenPoint();
 		final int height = pane.height();
 		if (view.x < 0 || view.y < 0 || height < 1) {


### PR DESCRIPTION
If the users bank is relatively empty (ie. not enough items to scroll) the bank attempts to scroll, but the scroll method returns false due to not being able to scroll. Potential fixes would be either to return true from the scroll method at this point, or just to check if you need to scroll in the bank method instead before calling it.

I chose this one as it seemed like it would be the best in case any other api methods have the same issue, this would resolve them all.