### PR TITLE
Viewport logic fix

### DIFF
--- a/src/main/java/org/powerbot/script/rt4/Game.java
+++ b/src/main/java/org/powerbot/script/rt4/Game.java
@@ -249,7 +249,8 @@ public class Game extends ClientAccessor {
 		if (resizable()) {
 			final Dimension d = dimensions();
 			return x >= 0 && y >= 0 && (x > 520 || y <= d.height - 170) &&
-					(x < d.width - 245 || y < d.height - 340 && y > 170);
+					(x < d.width - 245 || y < d.height - 340 && y > 170) &&
+					x <= (d.width - 1) && y <= (d.height - 1);
 		}
 		return x >= 4 && y >= 4 && x <= 515 && y <= 337;
 	}


### PR DESCRIPTION
There is a logic error in inViewport() : boolean where the upper x and y coordinates are not bounded in resizable mode. Points that are offscreen are being registered as being within the viewport even when they are not.

Current: 
![a](https://user-images.githubusercontent.com/6757526/35540712-3a55799c-0525-11e8-8b4f-02486bf274b0.png)

Fixed: 
![b](https://user-images.githubusercontent.com/6757526/35540718-3ee70926-0525-11e8-9e8e-ee401d350937.png)

