### PR TITLE
Bugfix for telegrabbing wines

### DIFF
--- a/src/main/java/org/powerbot/bot/rt4/RandomEvents.java
+++ b/src/main/java/org/powerbot/bot/rt4/RandomEvents.java
@@ -48,6 +48,10 @@ public class RandomEvents extends PollingScript<ClientContext> {
 				ctx.widgets.component(Constants.CHAT_WIDGET, Constants.CHAT_VIEWPORT).click();
 			}
 		}
+		if(ctx.magic.ready(Magic.Spell.TELEKINETIC_GRAB)) { // If the spell  telekinetic grab is ready to cast -> click somewhere on the screen; fixes bug, when telegrabbing wines
+		 ctx.input.click(665,350,true);
+			
+		}
 		if (npc.interact(false, "Dismiss")) {
 			Condition.wait(new Condition.Check() {
 				@Override


### PR DESCRIPTION
fixes the bug when the telegrab spell is ready to cast and a random event pops up