### PR TITLE
Revert "Bugfix for telegrabbing wines"

### DIFF
--- a/src/main/java/org/powerbot/bot/rt4/RandomEvents.java
+++ b/src/main/java/org/powerbot/bot/rt4/RandomEvents.java
@@ -48,10 +48,6 @@ public class RandomEvents extends PollingScript<ClientContext> {
 				ctx.widgets.component(Constants.CHAT_WIDGET, Constants.CHAT_VIEWPORT).click();
 			}
 		}
-		if(ctx.magic.ready(Magic.Spell.TELEKINETIC_GRAB)) { // If the spell  telekinetic grab is ready to cast -> click somewhere on the screen; fixes bug, when telegrabbing wines
-		 ctx.input.click(665,350,true);
-			
-		}
 		if (npc.interact(false, "Dismiss")) {
 			Condition.wait(new Condition.Check() {
 				@Override


### PR DESCRIPTION
Reverts powerbot/powerbot#1821

1. This does not compile;
2. Using hard-coded coordinates is not a proper solution;
3. This should be generalized to work for any pending spell cast;