### PR TITLE
Revert "Correct types"

### DIFF
--- a/src/main/java/org/powerbot/script/rt4/Worlds.java
+++ b/src/main/java/org/powerbot/script/rt4/Worlds.java
@@ -1,5 +1,6 @@
 package org.powerbot.script.rt4;
 
+import org.powerbot.script.AbstractQuery;
 import org.powerbot.script.Condition;
 import org.powerbot.script.Filter;
 
@@ -56,7 +57,7 @@ public class Worlds extends IdQuery<World> {
 	 * @param types The types to target.
 	 * @return this instance for chaining purposes.
 	 */
-	public IdQuery<World> types(final World.Type... types) {
+	public Worlds types(final World.Type... types) {
 		return select(new Filter<World>() {
 			public boolean accept(World world) {
 				for(World.Type t : types)
@@ -73,7 +74,7 @@ public class Worlds extends IdQuery<World> {
 	 * @param specialties The specialties to target.
 	 * @return this instance for chaining purposes.
 	 */
-	public IdQuery<World> specialties(final World.Specialty... specialties) {
+	public Worlds specialties(final World.Specialty... specialties) {
 		return select(new Filter<World>() {
 			public boolean accept(World world) {
 				for(World.Specialty s : specialties)
@@ -90,7 +91,7 @@ public class Worlds extends IdQuery<World> {
 	 * @param servers The server locations to filter.
 	 * @return This instance for chaining purposes.
 	 */
-	public IdQuery<World> servers(final World.Server... servers) {
+	public Worlds servers(final World.Server... servers) {
 		return select(new Filter<World>() {
 			public boolean accept(World world) {
 				for(World.Server s : servers)
@@ -108,7 +109,7 @@ public class Worlds extends IdQuery<World> {
 	 * @param population The population the worlds should be less than or equal to.
 	 * @return this instance for chaining purposes.
 	 */
-	public IdQuery<World> population(final int population) {
+	public Worlds population(final int population) {
 		return select(new Filter<World>() {
 			public boolean accept(World world) {
 				return world.size() <= population;
@@ -122,7 +123,7 @@ public class Worlds extends IdQuery<World> {
 	 *
 	 * @return this instance for chaining purposes.
 	 */
-	public IdQuery<World> joinable() {
+	public Worlds joinable() {
 		return select(new Filter<World>() {
 			public boolean accept(World world) {
 				return world.valid() &&


### PR DESCRIPTION
This reverts commit 41a4340c32fff19a99ae65c75f87cafa239d9b02.

Making Worlds-specific filters return `IdQuery` disallows consumers of the API from chaining queries. 