### PR TITLE
Faster valid checks for GameObjects

### DIFF
--- a/src/main/java/org/powerbot/script/rt4/GameObject.java
+++ b/src/main/java/org/powerbot/script/rt4/GameObject.java
@@ -206,7 +206,9 @@ public class GameObject extends Interactive implements Nameable, InteractiveEnti
 
 	@Override
 	public boolean valid() {
-		return !(object == null || object.object.isNull()) && ctx.objects.select(this, 0).contains(this);
+		return this != ctx.objects.nil()
+				&& !(object == null || object.object.isNull())
+				&& ctx.objects.select(this, 0).contains(this);
 	}
 
 	@Override

--- a/src/main/java/org/powerbot/script/rt4/Objects.java
+++ b/src/main/java/org/powerbot/script/rt4/Objects.java
@@ -14,10 +14,11 @@ import org.powerbot.script.Locatable;
  * Objects
  */
 public class Objects extends BasicQuery<GameObject> {
-	private static GameObject NIL;
+	private GameObject NIL;
 
 	public Objects(final ClientContext ctx) {
 		super(ctx);
+		NIL = new GameObject(ctx, null, GameObject.Type.UNKNOWN);
 	}
 
 	public BasicQuery<GameObject> select(final int radius) {
@@ -102,9 +103,6 @@ public class Objects extends BasicQuery<GameObject> {
 
 	@Override
 	public GameObject nil() {
-		if (NIL == null) {
-			NIL = new GameObject(ctx, null, GameObject.Type.UNKNOWN);
-		}
 		return NIL;
 	}
 }

--- a/src/main/java/org/powerbot/script/rt4/Objects.java
+++ b/src/main/java/org/powerbot/script/rt4/Objects.java
@@ -14,6 +14,8 @@ import org.powerbot.script.Locatable;
  * Objects
  */
 public class Objects extends BasicQuery<GameObject> {
+	private static GameObject NIL;
+
 	public Objects(final ClientContext ctx) {
 		super(ctx);
 	}
@@ -100,6 +102,9 @@ public class Objects extends BasicQuery<GameObject> {
 
 	@Override
 	public GameObject nil() {
-		return new GameObject(ctx, null, GameObject.Type.UNKNOWN);
+		if (NIL == null) {
+			NIL = new GameObject(ctx, null, GameObject.Type.UNKNOWN);
+		}
+		return NIL;
 	}
 }

--- a/src/main/java/org/powerbot/script/rt6/GameObject.java
+++ b/src/main/java/org/powerbot/script/rt6/GameObject.java
@@ -149,7 +149,9 @@ public class GameObject extends Interactive implements InteractiveEntity, Nameab
 
 	@Override
 	public boolean valid() {
-		return !(object == null || object.object.isNull()) && ctx.objects.select(this, 0).contains(this);
+		return this != ctx.objects.nil()
+				&& !(object == null || object.object.isNull())
+				&& ctx.objects.select(this, 0).contains(this);
 	}
 
 	@Override

--- a/src/main/java/org/powerbot/script/rt6/Objects.java
+++ b/src/main/java/org/powerbot/script/rt6/Objects.java
@@ -26,7 +26,7 @@ import org.powerbot.script.Locatable;
  * Utilities pertaining to in-game objects.
  */
 public class Objects extends MobileIdNameQuery<GameObject> {
-	private static GameObject NIL;
+	private GameObject NIL;
 
 	private static final Class<?> o_types[][] = {
 			{BoundaryObject.class, DynamicBoundaryObject.class}, {BoundaryObject.class, DynamicBoundaryObject.class},
@@ -41,6 +41,7 @@ public class Objects extends MobileIdNameQuery<GameObject> {
 
 	public Objects(final ClientContext factory) {
 		super(factory);
+		NIL = new GameObject(ctx, null, GameObject.Type.UNKNOWN);
 	}
 
 	public MobileIdNameQuery<GameObject> select(final int radius) {
@@ -155,9 +156,6 @@ public class Objects extends MobileIdNameQuery<GameObject> {
 	 */
 	@Override
 	public GameObject nil() {
-		if (NIL == null) {
-			NIL = new GameObject(ctx, null, GameObject.Type.UNKNOWN);
-		}
 		return NIL;
 	}
 }

--- a/src/main/java/org/powerbot/script/rt6/Objects.java
+++ b/src/main/java/org/powerbot/script/rt6/Objects.java
@@ -26,6 +26,8 @@ import org.powerbot.script.Locatable;
  * Utilities pertaining to in-game objects.
  */
 public class Objects extends MobileIdNameQuery<GameObject> {
+	private static GameObject NIL;
+
 	private static final Class<?> o_types[][] = {
 			{BoundaryObject.class, DynamicBoundaryObject.class}, {BoundaryObject.class, DynamicBoundaryObject.class},
 			{FloorObject.class, DynamicFloorObject.class},
@@ -153,6 +155,9 @@ public class Objects extends MobileIdNameQuery<GameObject> {
 	 */
 	@Override
 	public GameObject nil() {
-		return new GameObject(ctx, null, GameObject.Type.UNKNOWN);
+		if (NIL == null) {
+			NIL = new GameObject(ctx, null, GameObject.Type.UNKNOWN);
+		}
+		return NIL;
 	}
 }


### PR DESCRIPTION
Creates a static "NIL" instance that is lazy-loaded and used for `valid()` to improve validation speed.
99% of the time, when a script writer is calling `valid()`, they want to make sure it's not NIL. This does an additional, preliminary check that the object is not NIL.

Checking memory addresses is infinitely faster than a object query.