### PR TITLE
Fixes bank pin, rt4

### DIFF
--- a/src/main/java/org/powerbot/bot/rt4/BankPin.java
+++ b/src/main/java/org/powerbot/bot/rt4/BankPin.java
@@ -3,9 +3,11 @@ package org.powerbot.bot.rt4;
 import org.powerbot.misc.GameAccounts;
 import org.powerbot.script.Condition;
 import org.powerbot.script.PollingScript;
+import org.powerbot.script.Random;
 import org.powerbot.script.rt4.ClientContext;
 import org.powerbot.script.rt4.Component;
 import org.powerbot.script.rt4.Constants;
+import org.powerbot.script.rt4.Widget;
 
 public class BankPin extends PollingScript<ClientContext> {
 	public BankPin() {
@@ -32,7 +34,10 @@ public class BankPin extends PollingScript<ClientContext> {
 			return;
 		}
 
-		for (final Component c : ctx.widgets.widget(Constants.BANKPIN_WIDGET).components()) {
+		final int preCount = count;
+		final Widget w = ctx.widgets.widget(Constants.BANKPIN_WIDGET);
+
+		for (final Component c : w.components()) {
 			if (c.textColor() != 0 || c.width() != 64 || c.height() != 64 || c.componentCount() != 2 || !c.visible()) {
 				continue;
 			}
@@ -52,6 +57,9 @@ public class BankPin extends PollingScript<ClientContext> {
 					}, 100, 20);
 				}
 			}
+		}
+		if(preCount==count){
+			w.component(Random.nextInt(0,ctx.widgets.widget(Constants.BANKPIN_WIDGET).componentCount())).hover();
 		}
 	}
 

--- a/src/main/java/org/powerbot/bot/rt4/BankPin.java
+++ b/src/main/java/org/powerbot/bot/rt4/BankPin.java
@@ -58,8 +58,8 @@ public class BankPin extends PollingScript<ClientContext> {
 				}
 			}
 		}
-		if(preCount==count){
-			w.component(Random.nextInt(0,ctx.widgets.widget(Constants.BANKPIN_WIDGET).componentCount())).hover();
+		if (preCount == count) {
+			w.component(Random.nextInt(0, ctx.widgets.widget(Constants.BANKPIN_WIDGET).componentCount())).hover();
 		}
 	}
 


### PR DESCRIPTION
If next digit is hovered (since numbers reposition every click) the bot can not find the one to click. Added code checks if it was found and clicked, if not it will move the mouse.

https://github.com/powerbot/powerbot/issues/1865