### PR TITLE
Reduce thread sleep

### DIFF
--- a/src/main/java/org/powerbot/script/PollingScript.java
+++ b/src/main/java/org/powerbot/script/PollingScript.java
@@ -87,7 +87,7 @@ public abstract class PollingScript<C extends ClientContext> extends AbstractScr
 				}
 
 				try {
-					Thread.sleep(60);
+					Thread.sleep(10);
 				} catch (final InterruptedException ignored) {
 					Thread.yield();
 				}


### PR DESCRIPTION
ClientContext has 6 PollingScripts which results in a poll every 360ms, the sleep is too long for each one so it should be reduced.