### PR TITLE
Add an exists() method to AbstractQuery

### DIFF
--- a/src/main/java/org/powerbot/script/AbstractQuery.java
+++ b/src/main/java/org/powerbot/script/AbstractQuery.java
@@ -271,6 +271,15 @@ public abstract class AbstractQuery<T extends AbstractQuery<T, K, C>, K, C exten
 	public boolean isEmpty() {
 		return items.get().isEmpty();
 	}
+	
+	/**
+	* Returns {@code true} if the query cache contains one or more items.
+	*
+	* @return {@code true} if the query cache contains one or more items.
+	*/
+	public boolean exists() {
+		return !isEmpty();
+	}
 
 	/**
 	 * Returns {@code true} if the query cache contains the specified item.


### PR DESCRIPTION
The purpose of this is to add a simple method to find out if there's any viable denizens of the query without having to do something like poll().valid(), or size > 0.