### PR TITLE
Updating Bank#withdraw()

### DIFF
--- a/src/main/java/org/powerbot/script/rt4/Bank.java
+++ b/src/main/java/org/powerbot/script/rt4/Bank.java
@@ -246,7 +246,10 @@ public class Bank extends ItemQuery<Item> {
 		} else {
 			action = "Withdraw-X";
 		}
-		final int cache = ctx.inventory.select().count(true);
+		
+		final int cache;
+		if(!validate) cache = ctx.inventory.select().count(true);
+		
 		if(!item.component().visible()){
          	   ctx.bank.currentTab(0);
         	}

--- a/src/main/java/org/powerbot/script/rt4/Bank.java
+++ b/src/main/java/org/powerbot/script/rt4/Bank.java
@@ -213,9 +213,10 @@ public class Bank extends ItemQuery<Item> {
 	 *
 	 * @param item   the item instance
 	 * @param amount the amount to withdraw
+	 * @param validate whether to check if the item was successfully withdrawn
 	 * @return {@code true} if the item was withdrawn, does not determine if amount was matched; otherwise, {@code false}
 	 */
-	public boolean withdraw(final Item item, final int amount) {
+	public boolean withdraw(final Item item, final int amount, final boolean validate) {
 		if (!opened() || !item.valid() || amount < -1) {
 			return false;
 		}
@@ -271,14 +272,33 @@ public class Bank extends ItemQuery<Item> {
 				return false;
 			}
 			Condition.sleep();
-			ctx.input.sendln(amount + "");
+			if(!validate){
+				return ctx.input.sendln(amount + "");
+			}else{
+				ctx.input.sendln(amount + "");
+			}
 		}
+		if(!validate){
+			return false;
+		}
+		
 		return Condition.wait(new Condition.Check() {
 			@Override
 			public boolean poll() {
 				return cache != ctx.inventory.select().count(true);
 			}
 		});
+	}
+	
+	/**
+	 * Withdraws an item with the provided item and amount. Validates withdrawl
+	 *
+	 * @param item   the item instance
+	 * @param amount the amount to withdraw
+	 * @return {@code true} if the item was withdrawn, does not determine if amount was matched; otherwise, {@code false}
+	 */
+	public boolean withdraw(final Item item, final int amount){
+		return withdraw(item, amount, true);
 	}
 
 


### PR DESCRIPTION
Currently banking can take a while since it validates that it successfully withdrew the item. I'd like to allow the Script Writer to be able to choose to validate it himself, and instead move on to the next item to withdraw. This will help a lot for bank standing scripts as banking currently takes much too long in it's current form.

Even if we don't want to implement this I would definitely appreciate a future update bringing an option to withdraw without the wait.