### PR TITLE
Updating CacheConfigs

### DIFF
--- a/src/main/java/org/powerbot/script/rt4/CacheNpcConfig.java
+++ b/src/main/java/org/powerbot/script/rt4/CacheNpcConfig.java
@@ -48,6 +48,10 @@ public class CacheNpcConfig {
 		stream = new JagexStream(sector.getPayload());
 		read();
 	}
+	
+	public static CacheNpcConfig load(final int id){
+		return load(Bot.CACHE_WORKER, id);
+	}
 
 	static CacheNpcConfig load(final CacheWorker worker, final int id) {
 		final Block b = worker.getBlock(2, 9);

--- a/src/main/java/org/powerbot/script/rt4/CacheObjectConfig.java
+++ b/src/main/java/org/powerbot/script/rt4/CacheObjectConfig.java
@@ -12,7 +12,7 @@ import org.powerbot.bot.cache.JagexStream;
  * CacheObjectConfig
  * An object holding configuration data for a GameObject within Runescape.
  */
-class CacheObjectConfig {
+public class CacheObjectConfig {
 	public final int index;
 	private final JagexStream stream;
 	public String name = "null";
@@ -34,11 +34,14 @@ class CacheObjectConfig {
 	public int[] originalColors, modifiedColors;
 	public final Map<Integer, Object> params = new HashMap<Integer, Object>();
 
-	public CacheObjectConfig(final Block.Sector sector, final int index) {
+	CacheObjectConfig(final Block.Sector sector, final int index) {
 		this.index = index;
 		stream = new JagexStream(sector.getPayload());
 		read();
 	}
+	
+	public static CacheObjectConfig(final int id){
+		return load(Bot.CACHE_WORKER, id);
 
 	static CacheObjectConfig load(final CacheWorker worker, final int id) {
 		final Block b = worker.getBlock(2, 6);

--- a/src/main/java/org/powerbot/script/rt4/CacheObjectConfig.java
+++ b/src/main/java/org/powerbot/script/rt4/CacheObjectConfig.java
@@ -40,8 +40,9 @@ public class CacheObjectConfig {
 		read();
 	}
 	
-	public static CacheObjectConfig(final int id){
+	public static CacheObjectConfig load(final int id){
 		return load(Bot.CACHE_WORKER, id);
+	}
 
 	static CacheObjectConfig load(final CacheWorker worker, final int id) {
 		final Block b = worker.getBlock(2, 6);


### PR DESCRIPTION
RT4 configs were updated to make them more consistent with each other. They now all have public methods for getting the Config via an id parameter. The classes themselves are all public with private/package-private constructors.