### PR TITLE
remove animation check for default break

### DIFF
--- a/src/main/java/org/powerbot/script/PollingScript.java
+++ b/src/main/java/org/powerbot/script/PollingScript.java
@@ -138,21 +138,21 @@ public abstract class PollingScript<C extends ClientContext> extends AbstractScr
 			org.powerbot.script.rt4.ClientContext rt4ctx = (org.powerbot.script.rt4.ClientContext) ctx;
 			Player p = rt4ctx.players.local();
 
-			return (rt4ctx.bank.nearest().tile().distanceTo(p) < 5) && rt4ctx.npcs.select().within(5d).select(new Filter<Npc>() {
+			return (rt4ctx.npcs.select().within(5d).select(new Filter<Npc>() {
 				@Override
 				public boolean accept(final Npc npc) {
-					return npc.interacting().equals(p);
+					return npc.interacting().equals(p) && npc.inCombat();
 				}
-			}).isEmpty() && !p.inCombat();
+			}).isEmpty()) && !p.inCombat();
 		} else {
 			org.powerbot.script.rt6.ClientContext rt6ctx = (org.powerbot.script.rt6.ClientContext) ctx;
 			org.powerbot.script.rt6.Player p = rt6ctx.players.local();
-			return (rt6ctx.bank.nearest().tile().distanceTo(p) < 5) && rt6ctx.npcs.select().within(5d).select(new Filter<org.powerbot.script.rt6.Npc>() {
+			return (rt6ctx.npcs.select().within(5d).select(new Filter<org.powerbot.script.rt6.Npc>() {
 				@Override
 				public boolean accept(final org.powerbot.script.rt6.Npc npc) {
-					return npc.interacting().equals(p);
+					return npc.interacting().equals(p) && npc.inCombat();
 				}
-			}).isEmpty() && !p.inCombat();
+			}).isEmpty()) && !p.inCombat();
 		}
 	}
 }

--- a/src/main/java/org/powerbot/script/PollingScript.java
+++ b/src/main/java/org/powerbot/script/PollingScript.java
@@ -129,7 +129,7 @@ public abstract class PollingScript<C extends ClientContext> extends AbstractScr
 	}
 
 	/**
-	 * Called if the user specified run duration has been reached, triggering {@link Script.State#STOP} if true is returned.
+	 * Called if the user specified run duration has been reached, triggerig {@link Script.State#STOP} if true is returned.
 	 * @return true if script can safely be stopped
 	 */
 	public boolean canBreak() {
@@ -138,7 +138,7 @@ public abstract class PollingScript<C extends ClientContext> extends AbstractScr
 			org.powerbot.script.rt4.ClientContext rt4ctx = (org.powerbot.script.rt4.ClientContext) ctx;
 			Player p = rt4ctx.players.local();
 
-			return (p.animation() == -1 || rt4ctx.bank.nearest().tile().distanceTo(p) < 5) && rt4ctx.npcs.select().within(5d).select(new Filter<Npc>() {
+			return (rt4ctx.bank.nearest().tile().distanceTo(p) < 5) && rt4ctx.npcs.select().within(5d).select(new Filter<Npc>() {
 				@Override
 				public boolean accept(final Npc npc) {
 					return npc.interacting().equals(p);
@@ -147,7 +147,7 @@ public abstract class PollingScript<C extends ClientContext> extends AbstractScr
 		} else {
 			org.powerbot.script.rt6.ClientContext rt6ctx = (org.powerbot.script.rt6.ClientContext) ctx;
 			org.powerbot.script.rt6.Player p = rt6ctx.players.local();
-			return (p.animation() == -1 || rt6ctx.bank.nearest().tile().distanceTo(p) < 5) && rt6ctx.npcs.select().within(5d).select(new Filter<org.powerbot.script.rt6.Npc>() {
+			return (rt6ctx.bank.nearest().tile().distanceTo(p) < 5) && rt6ctx.npcs.select().within(5d).select(new Filter<org.powerbot.script.rt6.Npc>() {
 				@Override
 				public boolean accept(final org.powerbot.script.rt6.Npc npc) {
 					return npc.interacting().equals(p);


### PR DESCRIPTION
I believe majority of scripts are relying on the default #canBreak() thus it becomes a very bot-like thing when scripts only ever log out or pause after you have finished mining, or after you've finished fletching etc.

Since the new break handler will support actual breaks not just stops, it is much better if a user can pause mid-action. (i.e go checkout facebook while their character continues to cut a tree down).

Combat checks still remain, and a break will not engage during combat. However, if you are close to aggressive monsters you should be overriding canBreak yourself!