### PR TITLE
Update Constants.java

### DIFF
--- a/src/main/java/org/powerbot/script/rt6/Constants.java
+++ b/src/main/java/org/powerbot/script/rt6/Constants.java
@@ -131,7 +131,7 @@ public final class Constants {
 	public static final int LOBBY_CURRENT_WORLD = 116;
 	public static final int LOBBY_CLOSE = 307;
 	public static final int LOBBY_CLOSE_SUB = 1;
-	public static final int LOBBY_TABS = 98;
+	public static final int LOBBY_TABS = 91;
 	public static final int LOBBY_TAB_START = 3;
 	public static final int LOBBY_TAB_LENGTH = 4;
 	public static final int LOBBY_TAB_CURRENT = 27;


### PR DESCRIPTION
`ctx.lobby.tab()` currently returns `Tab.NONE`, which makes a lot of other functionality not work, either. For instance, `Lobby#worlds` also returns an empty list because of this.