### PR TITLE
Implements containsOrIntersects method for Area

### DIFF
--- a/src/main/java/org/powerbot/script/Area.java
+++ b/src/main/java/org/powerbot/script/Area.java
@@ -48,6 +48,16 @@ public class Area {
 		return true;
 	}
 
+	public boolean containsOrIntersects(final Locatable... locatables) {
+		for (final Locatable locatable : locatables) {
+			final Tile tile = locatable.tile();
+			if (tile.floor() != plane || (!polygon.contains(tile.x(), tile.y()) && !polygon.intersects(tile.x() - 0.5, tile.y() - 0.5, 1, 1))) {
+				return false;
+			}
+		}
+		return true;
+	}
+
 	public Tile getCentralTile() {
 		final Point point = PolygonUtils.getCenter(polygon);
 		return new Tile(point.x, point.y, plane);


### PR DESCRIPTION
Currently, we are experiencing issues using the contains method.

```
public static void main(String[] args) {
	Area area = new Area(new Tile(0,0), new Tile(2,2));
	System.out.println(area.contains(new Tile(0,0))); // true as expected
	System.out.println(area.contains(new Tile(0,1))); // true as expected
	System.out.println(area.contains(new Tile(1,0))); // true as expected
	System.out.println(area.contains(new Tile(2,2))); // false <-- This is the problem
	System.out.println(area.contains(new Tile(0,4))); // false as expected
	System.out.println(area.contains(new Tile(4,0))); // false as expected
}
```
The current `contains` method doesn't account for the Oracle [Definition of insideness](https://docs.oracle.com/javase/8/docs/api/java/awt/Shape.html#def_insideness) for points on the upper boundaries.

The newly proposed method checks whether the polygon contains the given point, and whether the point intersects the polygon boundary.  

Here's the result of the newly proposed method.
```
public static void main(String[] args) {
	Area area = new Area(new Tile(1,1), new Tile(3,3));
	System.out.println(area.containsOrIntersects(new Tile(1,1))); // true as expected
	System.out.println(area.containsOrIntersects(new Tile(1,2))); // true as expected
	System.out.println(area.containsOrIntersects(new Tile(2,1))); // true as expected
	System.out.println(area.containsOrIntersects(new Tile(3,1))); // true as expected
	System.out.println(area.containsOrIntersects(new Tile(3,3))); // true <-- Now working
	System.out.println(area.containsOrIntersects(new Tile(0,0))); // false as expected
	System.out.println(area.containsOrIntersects(new Tile(4,3))); // false as expected
	System.out.println(area.containsOrIntersects(new Tile(1,5))); // false as expected
	System.out.println(area.containsOrIntersects(new Tile(5,1))); // false as expected
}
```
If you look closer at the method, we can check whether the point is on the boundary, by negating 0.5 from the current X and Y value, and check whether it intersects the polygon with a height and width of 1. Example below;

![Example](https://puu.sh/C90Xw/5064d241aa.png)