### PR TITLE
More sensible mouse speed

### DIFF
--- a/src/main/java/org/powerbot/script/Input.java
+++ b/src/main/java/org/powerbot/script/Input.java
@@ -55,12 +55,12 @@ public abstract class Input {
 	
 	/**
 	 * Returns the current speed.
-	 * This is a sensitive function and should be used in exceptional circumstances for a short period of time only.
+	 * This is not accurate as values are lost during round off.
 	 *
-	 * @return the speed, which can be different to the value requested
+	 * @return the current speed
 	 */
 	public int mouseSpeed() {
-		return speed.get();
+		return 1000 / speed.get();
 	}
 
 	/**

--- a/src/main/java/org/powerbot/script/Input.java
+++ b/src/main/java/org/powerbot/script/Input.java
@@ -59,8 +59,10 @@ public abstract class Input {
 	 * @return the speed, which can be different to the value requested
 	 */
 	public int mouseSpeed(final float s) {
-		int speedInParisUnits = (int) (1000 / s);
-		speed.set(Math.min(100, Math.max(10, speedInParisUnits)));
+		if (s > 0 && s <= 100) {
+			int speedInParisUnits = (int) (1000 / s);
+			speed.set(speedInParisUnits);
+		}
 		return mouseSpeed();
 	}
 

--- a/src/main/java/org/powerbot/script/Input.java
+++ b/src/main/java/org/powerbot/script/Input.java
@@ -37,6 +37,46 @@ public abstract class Input {
 		speed.set(Math.min(100, Math.max(10, s)));
 		return speed.get();
 	}
+	
+	/**
+	 * Set the relative speed for mouse movements.
+	 * This is a sensitive function and should be used in exceptional circumstances for a short period of time only.
+	 *
+	 * @param s the new speed as a percentage, i.e. {@code 10} is 10x faster, {@code 25} is 4x as fast
+	 *          and {@code 100} is the full speed. Specifying {@code 0} will not change the speed but return the
+	 *          current value instead.
+	 * @return the speed, which can be different to the value requested
+	 */
+	@Deprecated
+	public int speed(final int s) {
+		speed.set(Math.min(100, Math.max(10, s)));
+		return speed.get();
+	}
+	
+	/**
+	 * Returns the current speed.
+	 * This is a sensitive function and should be used in exceptional circumstances for a short period of time only.
+	 *
+	 * @return the speed, which can be different to the value requested
+	 */
+	public int mouseSpeed() {
+		return speed.get();
+	}
+
+	/**
+	 * Set the relative speed for mouse movements.
+	 * This is a sensitive function and should be used in exceptional circumstances for a short period of time only.
+	 *
+	 * @param s the new speed as a percentage, i.e. {@code 10} is 10% of max, {@code 25} is 25% of max
+	 *          and {@code 100} is the full speed. Specifying values below {@code 1} or above {@code 100}
+	 *          will be avoided.
+	 * @return the speed, which can be different to the value requested
+	 */
+	public int mouseSpeed(final float s) {
+		int speedInParisUnits = (int) (1000 / s);
+		speed.set(Math.min(100, Math.max(10, speedInParisUnits)));
+		return mouseSpeed();
+	}
 
 	// TODO: remove boolean return values for input methods
 

--- a/src/main/java/org/powerbot/script/Input.java
+++ b/src/main/java/org/powerbot/script/Input.java
@@ -41,12 +41,12 @@ public abstract class Input {
 	
 	/**
 	 * Returns the current speed.
-	 * This is not accurate as values are lost during round off.
+	 * This may not be accurate as values are lost during round off.
 	 *
 	 * @return the current speed
 	 */
 	public int mouseSpeed() {
-		return 1000 / speed.get();
+		return (int) ((100 - speed.get()) / 0.9);
 	}
 
 	/**
@@ -54,13 +54,13 @@ public abstract class Input {
 	 * This is a sensitive function and should be used in exceptional circumstances for a short period of time only.
 	 *
 	 * @param s the new speed as a percentage, i.e. {@code 10} is 10% of max, {@code 25} is 25% of max
-	 *          and {@code 100} is the full speed. Specifying values below {@code 1} or above {@code 100}
+	 *          and {@code 100} is the full speed. Specifying values below {@code 0} or above {@code 100}
 	 *          will be avoided.
 	 * @return the speed, which can be different to the value requested
 	 */
 	public int mouseSpeed(final float s) {
-		if (s > 0 && s <= 100) {
-			int speedInParisUnits = (int) (1000 / s);
+		if (s >= 0 && s <= 100) {
+			int speedInParisUnits = (int) (100 - (s * 0.9));
 			speed.set(speedInParisUnits);
 		}
 		return mouseSpeed();

--- a/src/main/java/org/powerbot/script/Input.java
+++ b/src/main/java/org/powerbot/script/Input.java
@@ -23,20 +23,6 @@ public abstract class Input {
 		spline = new MouseSpline();
 		speed = new AtomicInteger(100);
 	}
-
-	/**
-	 * Set the relative speed for mouse movements.
-	 * This is a sensitive function and should be used in exceptional circumstances for a short period of time only.
-	 *
-	 * @param s the new speed as a percentage, i.e. {@code 10} is 10x faster, {@code 25} is 4x as fast
-	 *          and {@code 100} is the full speed. Specifying {@code 0} will not change the speed but return the
-	 *          current value instead.
-	 * @return the speed, which can be different to the value requested
-	 */
-	public int speed(final int s) {
-		speed.set(Math.min(100, Math.max(10, s)));
-		return speed.get();
-	}
 	
 	/**
 	 * Set the relative speed for mouse movements.


### PR DESCRIPTION
#2011 was closed without any suggestions or reasons behind it.
A good portion of the people don't seem to understand why mouse speed should be set in the way paris sets it. By using the formula 100 - (s * 0.9), you can get a percentage of the maximum speed the mouse can travel at.