### PR TITLE
Fix ProductionInterface component id

### DIFF
--- a/src/main/java/org/powerbot/script/rt6/ProductionInterface.java
+++ b/src/main/java/org/powerbot/script/rt6/ProductionInterface.java
@@ -14,7 +14,7 @@ public class ProductionInterface extends ClientAccessor {
 		super(ctx);
 	}
 
-	private static final int START_BUTTON_COMPONENT = 20;
+	private static final int START_BUTTON_COMPONENT = 12;
 	private static final int PROGRESS_INTERFACE_COMPONENT = 11;
 	private static final int ITEM_SELECTION_PANE_COMPONENT = 44;
 	private static final int ITEM_SCROLLBAR_COMPONENT = 47;


### PR DESCRIPTION
For `makeItem(), it uses the `START_BUTTON_COMPONENT ` component.

Component 20 is something else:
![image](https://user-images.githubusercontent.com/2440977/49330884-df259500-f549-11e8-947d-69a666e6684f.png)

Component 12 is proper:
![image](https://user-images.githubusercontent.com/2440977/49330885-e64ca300-f549-11e8-9165-87de69b1b1d1.png)
