### PR TITLE
Deprecate inCombat refactor into a new method

### DIFF
--- a/src/main/java/org/powerbot/script/rt4/Actor.java
+++ b/src/main/java/org/powerbot/script/rt4/Actor.java
@@ -110,12 +110,7 @@ public abstract class Actor extends Interactive implements InteractiveEntity, Na
 	 */
 	@Deprecated
 	public boolean inCombat() {
-		final Client client = ctx.client();
-		if (client == null) {
-			return false;
-		}
-		final CombatStatusData[] data = getBarData();
-		return data != null && data[1] != null && data[1].getCycleEnd() < client.getCycle();
+		return healthBarVisible();
 	}
 	
 	/**

--- a/src/main/java/org/powerbot/script/rt4/Actor.java
+++ b/src/main/java/org/powerbot/script/rt4/Actor.java
@@ -108,7 +108,23 @@ public abstract class Actor extends Interactive implements InteractiveEntity, Na
 	 *
 	 * @return {@code true} if the health bar is visible, {@code false} otherwise.
 	 */
+	@Deprecated
 	public boolean inCombat() {
+		final Client client = ctx.client();
+		if (client == null) {
+			return false;
+		}
+		final CombatStatusData[] data = getBarData();
+		return data != null && data[1] != null && data[1].getCycleEnd() < client.getCycle();
+	}
+	
+	/**
+	 * Whether or not the entity has a health bar displayed over their head. This can be
+	 * used to determine whether or not the entity is currently in combat.
+	 *
+	 * @return {@code true} if the health bar is visible, {@code false} otherwise.
+	 */
+	public boolean healthBarVisible() {
 		final Client client = ctx.client();
 		if (client == null) {
 			return false;


### PR DESCRIPTION
inCombat was very confusing for new people as its name is unintuitive unless you read the documentation. Deprecating it will discourage its use, and adding the new healthBarVisible method will still allow people to use the functionality when needed