### PR TITLE
Update osrs worlds list

### DIFF
--- a/src/main/java/org/powerbot/script/rt4/Worlds.java
+++ b/src/main/java/org/powerbot/script/rt4/Worlds.java
@@ -164,7 +164,7 @@ public class Worlds extends AbstractQuery<Worlds, World, ClientContext> implemen
 
 	protected final Component list() {
 		for (Component c : ctx.widgets.widget(WORLD_WIDGET).components()) {
-			if (c.width() == 174 && c.height() == 204) {
+			if (c.width() == 174 && c.componentCount() > 800) {
 				return c;
 			}
 		}


### PR DESCRIPTION
Closes #2031

Update has changed worlds list so filter component is always visible.
World list component is no longer a fixed height.
There's another component which does not contain world details, is the exact same dimensions as correct component and has 600 sub components.
New list contains 1092 sub components, but is subject to change as worlds are added or removed.
Hence I chose 800 to filter the correct component.