### PR TITLE
Fix viewport for world list scrolling

### DIFF
--- a/src/main/java/org/powerbot/script/rt4/World.java
+++ b/src/main/java/org/powerbot/script/rt4/World.java
@@ -187,7 +187,7 @@ public class World extends ClientAccessor
 			if (c.index() % 6 != 2 || !c.text().equalsIgnoreCase("" + number)) {
 				continue;
 			}
-			ctx.widgets.scroll(c, list, bar(), true);
+			ctx.widgets.scroll(c, viewport(), bar(), true);
 			if (c.click()) {
 				if (!ctx.chat.pendingInput()) {
 					if (!ctx.chat.continueChat("Switch")) {
@@ -204,6 +204,15 @@ public class World extends ClientAccessor
 	private Component component(int widget, int texture) {
 		for (Component c : ctx.widgets.widget(widget).components()) {
 			if (c.textureId() == texture) {
+				return c;
+			}
+		}
+		return null;
+	}
+
+	private Component viewport() {
+		for (Component c : ctx.widgets.widget(Worlds.WORLD_WIDGET).components()) {
+			if (c.width() == 174 && c.height() == 193) {
 				return c;
 			}
 		}

--- a/src/main/java/org/powerbot/script/rt4/World.java
+++ b/src/main/java/org/powerbot/script/rt4/World.java
@@ -212,11 +212,11 @@ public class World extends ClientAccessor
 
 	private Component container() {
 		int height = ctx.worlds.list().height();
-		return ctx.components.select(false,Worlds.WORLD_WIDGET).scrollHeight(height).poll();
+		return ctx.components.select(false, Worlds.WORLD_WIDGET).scrollHeight(height).poll();
 	}
 
 	private Component bar() {
-		return ctx.components.select(false,Worlds.WORLD_WIDGET).select(c->c.componentCount() == 6).poll();
+		return ctx.components.select(false, Worlds.WORLD_WIDGET).select(c -> c.componentCount() == 6).poll();
 	}
 
 	@Override

--- a/src/main/java/org/powerbot/script/rt4/World.java
+++ b/src/main/java/org/powerbot/script/rt4/World.java
@@ -180,14 +180,14 @@ public class World extends ClientAccessor
 		}
 		ctx.worlds.open();
 		Component list = ctx.worlds.list();
-		if (list == null || !list.visible()) {
+		if (!list.valid()) {
 			return false;
 		}
 		for (Component c : list.components()) {
 			if (c.index() % 6 != 2 || !c.text().equalsIgnoreCase("" + number)) {
 				continue;
 			}
-			ctx.widgets.scroll(c, viewport(), bar(), true);
+			ctx.widgets.scroll(c, container(), bar(), true);
 			if (c.click()) {
 				if (!ctx.chat.pendingInput()) {
 					if (!ctx.chat.continueChat("Switch")) {
@@ -210,22 +210,13 @@ public class World extends ClientAccessor
 		return null;
 	}
 
-	private Component viewport() {
-		for (Component c : ctx.widgets.widget(Worlds.WORLD_WIDGET).components()) {
-			if (c.width() == 174 && c.height() == 193) {
-				return c;
-			}
-		}
-		return null;
+	private Component container() {
+		int height = ctx.worlds.list().height();
+		return ctx.components.select(false,Worlds.WORLD_WIDGET).scrollHeight(height).poll();
 	}
 
 	private Component bar() {
-		for (Component c : ctx.widgets.widget(Worlds.WORLD_WIDGET).components()) {
-			if (c.components().length == 6) {
-				return c;
-			}
-		}
-		return null;
+		return ctx.components.select(false,Worlds.WORLD_WIDGET).select(c->c.componentCount() == 6).poll();
 	}
 
 	@Override

--- a/src/main/java/org/powerbot/script/rt4/Worlds.java
+++ b/src/main/java/org/powerbot/script/rt4/Worlds.java
@@ -163,11 +163,11 @@ public class Worlds extends AbstractQuery<Worlds, World, ClientContext> implemen
 	}
 
 	protected final Component list() {
-		return ctx.components.select(false,WORLD_WIDGET).select(c->c.componentCount() > 800).width(174).poll();
+		return ctx.components.select(false, WORLD_WIDGET).select(c -> c.componentCount() > 800).width(174).poll();
 	}
 
 	protected final Component component(int widget, String text) {
-		return ctx.components.select(widget).select(c->c.text().equalsIgnoreCase(text)).poll();
+		return ctx.components.select(widget).select(c -> c.text().equalsIgnoreCase(text)).poll();
 	}
 
 	@Override

--- a/src/main/java/org/powerbot/script/rt4/Worlds.java
+++ b/src/main/java/org/powerbot/script/rt4/Worlds.java
@@ -33,7 +33,7 @@ public class Worlds extends AbstractQuery<Worlds, World, ClientContext> implemen
 	protected List<World> get() {
 		ArrayList<World> worlds = new ArrayList<World>();
 		Component list = list();
-		if (list == null) {
+		if (!list.valid()) {
 			return cache;
 		}
 		Component[] comps = list.components();
@@ -150,7 +150,7 @@ public class Worlds extends AbstractQuery<Worlds, World, ClientContext> implemen
 			return true;
 		}
 		Component c = component(LOGOUT_WIDGET, "World Switcher");
-		return c != null && c.click() && Condition.wait(new Condition.Check() {
+		return c.valid() && c.click() && Condition.wait(new Condition.Check() {
 			public boolean poll() {
 				return ctx.widgets.widget(WORLD_WIDGET).valid();
 			}
@@ -163,21 +163,11 @@ public class Worlds extends AbstractQuery<Worlds, World, ClientContext> implemen
 	}
 
 	protected final Component list() {
-		for (Component c : ctx.widgets.widget(WORLD_WIDGET).components()) {
-			if (c.width() == 174 && c.componentCount() > 800) {
-				return c;
-			}
-		}
-		return null;
+		return ctx.components.select(false,WORLD_WIDGET).select(c->c.componentCount() > 800).width(174).poll();
 	}
 
 	protected final Component component(int widget, String text) {
-		for (Component c : ctx.widgets.widget(widget).components()) {
-			if (c.text().equalsIgnoreCase(text)) {
-				return c;
-			}
-		}
-		return null;
+		return ctx.components.select(widget).select(c->c.text().equalsIgnoreCase(text)).poll();
 	}
 
 	@Override


### PR DESCRIPTION
Fixing world list scrolling by adding a new method to get the viewport.

I didn't realise the world list was also being used as the scroll viewport. The new list is now > 2000 pixels high and doesn't work for scrolling.