### PR TITLE
Change chat getContinue to use component query

### DIFF
--- a/src/main/java/org/powerbot/script/rt4/Chat.java
+++ b/src/main/java/org/powerbot/script/rt4/Chat.java
@@ -126,7 +126,7 @@ public class Chat extends TextQuery<ChatOption> {
 
 	private Component getContinue() {
 		for (final int[] a : Constants.CHAT_CONTINUES) {
-			final Component c = ctx.widgets.component(a[0], a[1]);
+			final Component c = ctx.components.select(false, a[0]).textContains("Click here to continue").poll();
 			if (!c.valid()) {
 				continue;
 			}


### PR DESCRIPTION
The level up prompt offsets the continue component depending on how many new items you are able to make.

The constant {11, 3} would not have worked in this case as the continue component was offset to the 4th component.

Although I don't ever recall the text being different, if the "Click here to continue" text is different somewhere, this will break.

https://i.imgur.com/lYIHPmk.png