### PR TITLE
Update Constants.java

### DIFF
--- a/src/main/java/org/powerbot/script/rt4/Constants.java
+++ b/src/main/java/org/powerbot/script/rt4/Constants.java
@@ -160,7 +160,7 @@ public final class Constants {
 	public static final int SPELLBOOK_VARPBIT = 439;
 	public static final int SPELLBOOK_WIDGET = 218;
 
-	public static final String[] BANK_NPCS = {"Banker", "Ghost banker", "Banker tutor", "Sirsal Banker", "Nardah Banker", "Gnome banker", "Fadli", "Emerald Benedict"};
+	public static final String[] BANK_NPCS = {"Banker", "Ghost banker", "Banker tutor", "Sirsal Banker", "Nardah Banker", "Gnome banker", "Fadli", "Emerald Benedict", "Arnold Lydspor", "Cornelius", "Gundai", "Jade", "TzHaar-Ket-Yil", "TzHaar-Ket-Zuh", "Jumaane", "Magnus Gram", "Yusuf"};
 	public static final String[] BANK_CHESTS = {"Bank chest", "Bank Chest-wreck"};
 	public static final String[] BANK_BOOTHS = {"Bank booth"};
 	public static final Tile[] BANK_UNREACHABLES = new Tile[]{


### PR DESCRIPTION
Add other npc banks.
This includes banks which require completing a quest before using. There is no alternative bank nearby these npcs that don't have that requirement, so it is difficult to mess this up.

Cornelius - Burgh de Rott (after In Aid of the Myreque)
Arnold Lydspor - Piscatoris (after Swan Song)
Gundai - Mage arena bank
Jade - Warriors guild
TzHaar-Ket-Yil - Mor Ul Rek
TzHaar-Ket-Zuh - Outer Mor Ul Rek
Jumaane - Ape Atoll (after MM2)
Magnus Gram - Jatizso (cannot be reached before having reqs)
Yusuf - Corsair cove (after the Corsair Curse)

Did not add Eniola who requires 20 runes and setting up chat before being able to right-click use.
Did not add Squire as shares name with other npcs.
Did not add Odovacar as requires 100 gp per inventory.

See https://oldschool.runescape.wiki/w/Banker for full ist